### PR TITLE
Add transfer of dicts. 

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -37,8 +37,8 @@ jobs:
     - name: Get MAD Binaries
       run: |
         mkdir src/pymadng/bin 
-        curl https://madx.web.cern.ch/releases/madng/1.1/mad-linux-1.1.2 -o src/pymadng/bin/mad_Linux
-        curl https://madx.web.cern.ch/releases/madng/1.1/mad-macos-1.1.2 -o src/pymadng/bin/mad_Darwin
+        curl https://madx.web.cern.ch/releases/madng/1.1/mad-linux-1.1.3 -o src/pymadng/bin/mad_Linux
+        curl https://madx.web.cern.ch/releases/madng/1.1/mad-macos-1.1.3 -o src/pymadng/bin/mad_Darwin
         chmod +x src/pymadng/bin/mad_Linux src/pymadng/bin/mad_Darwin
     - name: Build package
       run: python -m build

--- a/.github/workflows/test-pymadng.yml
+++ b/.github/workflows/test-pymadng.yml
@@ -33,8 +33,8 @@ jobs:
     - name: Get MAD Binaries
       run: |
         mkdir ./src/pymadng/bin 
-        curl https://madx.web.cern.ch/releases/madng/1.1/mad-linux-1.1.2 -o ./src/pymadng/bin/mad_Linux
-        curl https://madx.web.cern.ch/releases/madng/1.1/mad-macos-1.1.2 -o ./src/pymadng/bin/mad_Darwin
+        curl https://madx.web.cern.ch/releases/madng/1.1/mad-linux-1.1.3 -o ./src/pymadng/bin/mad_Linux
+        curl https://madx.web.cern.ch/releases/madng/1.1/mad-macos-1.1.3 -o ./src/pymadng/bin/mad_Darwin
         chmod +x ./src/pymadng/bin/mad_Linux ./src/pymadng/bin/mad_Darwin
     - name: Install dependencies
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
-0.6.3 (2024/30/05)
+0.7.0 (2025/06/05)
+Update to MAD-NG 1.1.3 \
+Breaking change: tables in lua are always returned as references, so you must use `eval` to get the value of the table. Or use the optional second argument in `py:send` such as `py:send(data, true)` to return the value of the table. \
+Dictionaries in python can now be sent to MAD-NG, and will be converted to a lua table. \
+Add an optional parameter to to_df and convert_to_dataframe methods to allow the user to specify to always return a pandas dataframe, instead of a tfs dataframe, when tfs is installed. \
+Update the documentation and examples to work again. \
+Remove iter restriction on MAD-NG objects that are not sequences, now all objects can be iterated over. \
+
+
+0.6.3 (2025/04/30)
 
 Update to MAD-NG 1.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Dictionaries in python can now be sent to MAD-NG, and will be converted to a lua
 Add an optional parameter to to_df and convert_to_dataframe methods to allow the user to specify to always return a pandas dataframe, instead of a tfs dataframe, when tfs is installed. \
 Update the documentation and examples to work again. \
 Remove iter restriction on MAD-NG objects that are not sequences, now all objects can be iterated over. \
+Renamed redirect_sterr to redirect_stderr in the MAD object, fixing a typo. \
 
 
 0.6.3 (2025/04/30)

--- a/docs/source/advanced_features.md
+++ b/docs/source/advanced_features.md
@@ -67,7 +67,7 @@ MAD-NG supports callbacks and iterative evaluations, which can be tied into Pyth
 In MAD:
 ```lua
 function twiss_and_send()
-  local tbl, flow = twiss {sequence=seq, method=4}
+  local tbl, flow = twiss {sequence=seq}
   py:send({tbl.s, tbl.beta11})
   return tbl, flow
 end

--- a/docs/source/communication.md
+++ b/docs/source/communication.md
@@ -89,8 +89,8 @@ If the object is not an `mtable`, a `TypeError` will be raised.
 ```
 
 See:
-```{literalinclude} ../../examples/ex-ps-twiss/ps-twiss.py
-:lines: 18, 24, 41-49
+```{literalinclude} ../../examples/ex-ps-twiss/ex-ps-twiss.py
+:lines: 19, 25, 42-53
 :linenos:
 ```
 

--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -64,8 +64,7 @@ python -m unittest tests/*.py
 ## Best Practices
 
 ### Code Style
-- Follow PEP8 (enforced via linters)
-- Use descriptive names for MAD objects (e.g. `tw`, `flow`, `seq`)
+- Use descriptive names for everything
 - Keep high-level user APIs separate from internal helpers
 - Use Ruff for code and import formatting.
 

--- a/docs/source/ex-lhc-couplingLocal.rst
+++ b/docs/source/ex-lhc-couplingLocal.rst
@@ -5,7 +5,7 @@ LHC Example
    :local:
    :depth: 2
 
-The file :ref:`ex-lhc-couplingLocal/lhc-couplingLocal.py <ex-lhc>` contains an example of loading the required files to use and run the LHC, while including a method to receive and plot intermediate results of a match.
+The file :ref:`ex-lhc-couplingLocal/ex-lhc-couplingLocal.py <ex-lhc>` contains an example of loading the required files to use and run the LHC, while including a method to receive and plot intermediate results of a match.
 
 Loading the LHC 
 ---------------
@@ -14,8 +14,8 @@ The following lines loads the required variables and files for the example. ``as
 
 To grab variables from the MAD-X environment, we use ``mad.load("MADX", ...)``.
 
-.. literalinclude:: ../../examples/ex-lhc-couplingLocal/lhc-couplingLocal.py
-    :lines: 12-22
+.. literalinclude:: ../../examples/ex-lhc-couplingLocal/ex-lhc-couplingLocal.py
+    :lines: 20-28
     :linenos:
 
 Receving intermediate results
@@ -25,80 +25,80 @@ The most complicated part of the example includes the following set of lines.
 
 From lines 4 - 8 below, we define a function that will be invoked during the optimization process at each iteration. Within this function, we perform a twiss for the match function to use, while also sending some information on the twiss to python, on line 6. 
 
-From lines 10 - 21, we run a match, with a **reference** to the match result returned to the variable ``match_rtrn``. Line 22 is a very important line, as this is something you place in the pipe to MAD-NG for MAD-NG to execute once the match is done. Lines 23-25 receive the first result returned during the match, so that we can start plotting the results.
+From lines 10 - 23, we run a match, with a **reference** to the match result returned to the variable ``match_rtrn``. Line 24 is a very important line, as this is something you place in the pipe to MAD-NG for MAD-NG to execute once the match is done. Lines 23-25 receive the first result returned during the match, so that we can start plotting the results.
 
-The plotting occurs between lines 27 - 36, wtih the while loop continuing until twiss result is ``None``, which occurs when the match is done, as requested on line 22.
+The plotting occurs between lines 29 - 38, wtih the while loop continuing until twiss result is ``None``, which occurs when the match is done, as requested on line 24.
 
-Finally, on lines 38 and 39, we retrieve the results of the match from the variable ``match_rtrn``. Since ``match_rtrn`` is a *temporary variable*, there is a limit to how many of these that can be stored (see :doc:`/advanced_features` for more information on these), we delete the reference in python to clear the temporary variable so that is is available for future use.
+Finally, on lines 40 and 41, we retrieve the results of the match from the variable ``match_rtrn``. Since ``match_rtrn`` is a *temporary variable*, there is a limit to how many of these that can be stored (see :doc:`/advanced_features` for more information on these), we delete the reference in python to clear the temporary variable so that is is available for future use.
 
 .. important::
     As MAD-NG is running in the background, the variable ``match_rtrn`` contains *no* information and instead must be queried for the results. During the query, python will then have to wait for MAD-NG to finish the match, and then return the results. On the other hand, if we do not query for the results, the match will continue to run in the background, we can do other things in python, and then query for the results later.
 
-.. literalinclude:: ../../examples/ex-lhc-couplingLocal/lhc-couplingLocal.py
-    :lines: 39-77
+.. literalinclude:: ../../examples/ex-lhc-couplingLocal/ex-lhc-couplingLocal.py
+    :lines: 50-90
     :linenos:
 
-LHC Speed Tests
----------------
+.. LHC Speed Tests
+.. ---------------
 
-This file creates functions within MAD-NG, ``LHC_load``, which loads the LHC and ``reg_expr``, which looks through the MADX environment and places anything that is a deferred expression into the table ``expr``.
+.. This file creates functions within MAD-NG, ``LHC_load``, which loads the LHC and ``reg_expr``, which looks through the MADX environment and places anything that is a deferred expression into the table ``expr``.
 
-The ``LHC_load`` function sends a string ``"done"`` afterwards, so that Python can stay in sync and time the LHC correctly.
+.. The ``LHC_load`` function sends a string ``"done"`` afterwards, so that Python can stay in sync and time the LHC correctly.
 
-The code below just runs the function and times it.
+.. The code below just runs the function and times it.
 
-.. literalinclude:: ../../examples/ex-recv-lhc/ex-defexpr.py
-    :lines: 44-47
-
-
-The ``reg_expr`` fucntion is recursive so, after calling the function, to ensure Python stays in sync, Python is required to ask MAD-NG for the string ``"done"``.
-
-.. literalinclude:: ../../examples/ex-recv-lhc/ex-defexpr.py
-    :lines: 50-53
-
-Next, we have the first of two methods to evaluate every deferred expression in the LHC and receive them, where Python performs a loop through the number of deferred expressions and has to ask MAD-NG everytime to receive the result.
-
-.. literalinclude:: ../../examples/ex-recv-lhc/ex-defexpr.py
-    :lines: 60-64
-
-The second method involves making MAD-NG do a loop at the same time as python and therefore does not require back on forth communication, which speeds up the transfer of data
-
-.. literalinclude:: ../../examples/ex-recv-lhc/ex-defexpr.py
-    :lines: 67-71
-
-The two methods above do not store the data, so the next bit of code is identical to above, but uses list comprehension to store the data into a list automatically, storing the lists into variables ``exprList1`` and ``exprList2``. The main point of seperating the methods above and below was to identify if storing the variables into a list was a bottleneck.
-
-.. literalinclude:: ../../examples/ex-recv-lhc/ex-defexpr.py
-    :lines: 74-77, 79-83
+.. .. literalinclude:: ../../examples/ex-recv-lhc/ex-defexpr.py
+..     :lines: 44-47
 
 
-While we have the LHC loaded, the next example grabs the name of every element in the sequence ``lhcb1``, demonstrating the ability and speed of pymadng and MAD-NG, other attributes could also be grabbed, but for simplicity this code just gets the names. This bit of code also uses list comprehension while making MAD-NG loop at the same time as Python.
+.. The ``reg_expr`` fucntion is recursive so, after calling the function, to ensure Python stays in sync, Python is required to ask MAD-NG for the string ``"done"``.
 
-.. literalinclude:: ../../examples/ex-recv-lhc/ex-defexpr.py
-    :lines: 89-99
+.. .. literalinclude:: ../../examples/ex-recv-lhc/ex-defexpr.py
+..     :lines: 50-53
 
-Another method, not shown above could be to create an entire list on the side of MAD-NG and then send the entire list to python. Which is done below, where instead all the names from the sequence ``lhcb2`` are taken from MAD-NG.
+.. Next, we have the first of two methods to evaluate every deferred expression in the LHC and receive them, where Python performs a loop through the number of deferred expressions and has to ask MAD-NG everytime to receive the result.
 
-.. literalinclude:: ../../examples/ex-recv-lhc/ex-defexpr.py
-    :lines: 104-114
+.. .. literalinclude:: ../../examples/ex-recv-lhc/ex-defexpr.py
+..     :lines: 60-64
 
-You can run the file yourself to retrieve the timings, but below is one run on an Intel® Core™ i7-8550U CPU @ 1.80GHz × 8 in Ubuntu 22.04.1 LTS
+.. The second method involves making MAD-NG do a loop at the same time as python and therefore does not require back on forth communication, which speeds up the transfer of data
 
-.. code-block:: console
+.. .. literalinclude:: ../../examples/ex-recv-lhc/ex-defexpr.py
+..     :lines: 67-71
 
-    Load time: 0.3955872058868408  sec
-    reg_expr time: 0.034337759017944336  sec
+.. The two methods above do not store the data, so the next bit of code is identical to above, but uses list comprehension to store the data into a list automatically, storing the lists into variables ``exprList1`` and ``exprList2``. The main point of seperating the methods above and below was to identify if storing the variables into a list was a bottleneck.
 
-For evaluating the deferred expressions
+.. .. literalinclude:: ../../examples/ex-recv-lhc/ex-defexpr.py
+..     :lines: 74-77, 79-83
 
-.. code-block:: console
 
-    eval time method 1: 0.5888900756835938  sec
-    eval time method 2: 0.2224569320678711  sec
-    eval time method 3: 0.6652431488037109  sec
-    eval time method 4: 0.21885156631469727  sec
+.. While we have the LHC loaded, the next example grabs the name of every element in the sequence ``lhcb1``, demonstrating the ability and speed of pymadng and MAD-NG, other attributes could also be grabbed, but for simplicity this code just gets the names. This bit of code also uses list comprehension while making MAD-NG loop at the same time as Python.
 
-.. code-block:: console
+.. .. literalinclude:: ../../examples/ex-recv-lhc/ex-defexpr.py
+..     :lines: 89-99
+
+.. Another method, not shown above could be to create an entire list on the side of MAD-NG and then send the entire list to python. Which is done below, where instead all the names from the sequence ``lhcb2`` are taken from MAD-NG.
+
+.. .. literalinclude:: ../../examples/ex-recv-lhc/ex-defexpr.py
+..     :lines: 104-114
+
+.. You can run the file yourself to retrieve the timings, but below is one run on an Intel® Core™ i7-8550U CPU @ 1.80GHz × 8 in Ubuntu 22.04.1 LTS
+
+.. .. code-block:: console
+
+..     Load time: 0.3955872058868408  sec
+..     reg_expr time: 0.034337759017944336  sec
+
+.. For evaluating the deferred expressions
+
+.. .. code-block:: console
+
+..     eval time method 1: 0.5888900756835938  sec
+..     eval time method 2: 0.2224569320678711  sec
+..     eval time method 3: 0.6652431488037109  sec
+..     eval time method 4: 0.21885156631469727  sec
+
+.. .. code-block:: console
     
-    time to retrieve every element name in lhcb1 sequence 0.024236202239990234 sec
-    time to retrieve every element name in lhcb2 sequence 0.0245511531829834 sec
+..     time to retrieve every element name in lhcb1 sequence 0.024236202239990234 sec
+..     time to retrieve every element name in lhcb2 sequence 0.0245511531829834 sec

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -19,7 +19,7 @@ PS Twiss Example
 
 .. _ex-ps-twiss:
 
-.. literalinclude:: ../../examples/ex-ps-twiss/ps-twiss.py
+.. literalinclude:: ../../examples/ex-ps-twiss/ex-ps-twiss.py
    :linenos:
 
 
@@ -28,7 +28,7 @@ LHC Example
 
 .. _ex-lhc:
 
-.. literalinclude:: ../../examples/ex-lhc-couplingLocal/lhc-couplingLocal.py
+.. literalinclude:: ../../examples/ex-lhc-couplingLocal/ex-lhc-couplingLocal.py
    :linenos:
 
 Managing References Example

--- a/docs/source/quickstartguide.md
+++ b/docs/source/quickstartguide.md
@@ -53,7 +53,7 @@ mad.seq.beam = mad.beam()
 ### Low-Level:
 
 ```python
-mad.send("seq.beam = beam")
+mad.send("seq.beam = beam {}")
 ```
 
 ---
@@ -63,13 +63,13 @@ mad.send("seq.beam = beam")
 ### High-Level:
 
 ```python
-mad["tbl", "flow"] = mad.twiss(sequence=mad.seq, method=4)
+mad["tbl", "flw"] = mad.twiss(sequence=mad.seq)
 ```
 
 ### Low-Level:
 
 ```python
-mad.send("tbl, flow = twiss {sequence=seq, method=4}")
+mad.send("tbl, flw = twiss {sequence=seq}")
 mad.send("py:send(tbl)")
 tbl = mad.recv()
 ```

--- a/examples/ex-LowLevel/ex-send-recv.py
+++ b/examples/ex-LowLevel/ex-send-recv.py
@@ -1,18 +1,20 @@
-from pymadng import MAD
-import numpy as np
-import time, sys
+import time
 
-arr0 = np.zeros((10000, 1000)) + 1j# 2*10000*1000*8 -> 160 MB
+import numpy as np
+
+from pymadng import MAD
+
+arr0 = np.zeros((10000, 1000)) + 1j  # 2*10000*1000*8 -> 160 MB
 
 start_time = time.time()
-mad = MAD(debug = False)
+mad = MAD(debug=False)
 # Number one rule! If you ask mad to send you something, read it!
 # Don't ask mad to send you data, then try to send more data, this will lead to a deadlock!
 
-mad.send("cm1 = py:recv()") # Tell MAD to receive something 
-mad.send(arr0)              # Send the data to MAD
+mad.send("cm1 = py:recv()")  # Tell MAD to receive something
+mad.send(arr0)  # Send the data to MAD
 
-mad.send("cm2 = py:recv()") 
+mad.send("cm2 = py:recv()")
 mad.send(arr0)
 
 mad.send("cm3 = py:recv()")
@@ -37,25 +39,37 @@ cmatrixString = """
     """
 
 start_time = time.time()
-mad.send(cmatrixString.format("cm1", "*", 2)) # Set cm1 to cm1 * 2 and send it to Python
+mad.send(
+    cmatrixString.format("cm1", "*", 2)
+)  # Set cm1 to cm1 * 2 and send it to Python
 cm1 = mad.recv()
-mad.send(cmatrixString.format("cm2", "*", 2)) # Set cm2 to cm1 * 2 and send it to Python
+mad.send(
+    cmatrixString.format("cm2", "*", 2)
+)  # Set cm2 to cm1 * 2 and send it to Python
 cm2 = mad.recv()
-mad.send(cmatrixString.format("cm3", "/", 3)) # Set cm3 to cm1 / 3 and send it to Python 
+mad.send(
+    cmatrixString.format("cm3", "/", 3)
+)  # Set cm3 to cm1 / 3 and send it to Python
 cm3 = mad.recv()
-mad.send(cmatrixString.format("cm4", "*", 1)) # Set cm4 to cm1 * 1 and send it to Python
+mad.send(
+    cmatrixString.format("cm4", "*", 1)
+)  # Set cm4 to cm1 * 1 and send it to Python
 cm4 = mad.recv()
-mad.send(cmatrixString.format("cm4", "*", 2)) # Set cm4 to cm1 * 1 and send it to Python
+mad.send(
+    cmatrixString.format("cm4", "*", 2)
+)  # Set cm4 to cm1 * 1 and send it to Python
 cm4 = mad.recv()
-mad.send(cmatrixString.format("cm4", "*", 2)) # Set cm4 to cm1 * 1 and send it to Python
+mad.send(
+    cmatrixString.format("cm4", "*", 2)
+)  # Set cm4 to cm1 * 1 and send it to Python
 cm4 = mad.recv()
 print("time to read 960 MB from MAD", time.time() - start_time)
 
 # Check that the data is correct
-print(np.all(cm1 == arr0*2))
-print(np.all(cm2 == arr0*2))
-print(np.all(cm3 == arr0/3))
-print(np.all(cm4 == arr0*4))
+print(np.all(cm1 == arr0 * 2))
+print(np.all(cm2 == arr0 * 2))
+print(np.all(cm3 == arr0 / 3))
+print(np.all(cm4 == arr0 * 4))
 
 
 # Send a string to MAD that will send a string back to Python

--- a/examples/ex-benchmark-and-fork/ex-benchmark-and-fork.py
+++ b/examples/ex-benchmark-and-fork/ex-benchmark-and-fork.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from pymadng import MAD
 
-orginal_dir = os.getcwd()
+original_dir = os.getcwd()
 os.chdir(os.path.dirname(os.path.realpath(__file__)))
 
 pid = os.fork()
@@ -104,4 +104,4 @@ else:
         print(mad.mtbl2.header)
     sys.exit()  # exit the child process
 
-os.chdir(orginal_dir)
+os.chdir(original_dir)

--- a/examples/ex-fodo/ex-fodos.py
+++ b/examples/ex-fodo/ex-fodos.py
@@ -1,6 +1,9 @@
-from pymadng import MAD
+import os
+
 import matplotlib.pyplot as plt
-import os 
+
+from pymadng import MAD
+
 orginal_dir = os.getcwd()
 os.chdir(os.path.dirname(os.path.realpath(__file__)))
 
@@ -10,17 +13,22 @@ with MAD() as mad:
     MADX:load("fodo.seq", "fodo.mad")
     local seq in MADX
     seq.beam = beam -- use default beam
-    mtbl, mflw = twiss {sequence=seq, method=4, implicit=true, nslice=10, save="atbody"}
+    mtbl, mflw = twiss {sequence=seq, implicit=true, nslice=10, save="atbody"}
     py:send(mtbl)
     """)
     mtbl = mad.recv("mtbl")
     plt.plot(mtbl.s, mtbl.beta11, "r-", label="Method 1")
 
     mad.send("""py:send(mtbl.s) ; py:send(mtbl.beta11)""")
-    plt.plot(mad.recv(), mad.recv(), "g--", label="Method 2", ) 
+    plt.plot(
+        mad.recv(),
+        mad.recv(),
+        "g--",
+        label="Method 2",
+    )
 
     plt.plot(mad.mtbl.s, mad.mtbl.beta11, "b:", label="Method 3")
-    
+
     plt.legend()
     plt.show()
 
@@ -29,13 +37,17 @@ with MAD() as mad:
     mad.MADX.load("'fodo.seq'", "'fodo.mad'")
     mad.load("MADX", "seq")
     mad.seq.beam = mad.beam()
-    mad["mtbl", "mflw"] = mad.twiss(sequence=mad.seq, method=4, implicit=True, nslice=10, save="'atbody'")
-    cols = mad.quote_strings(["name", "s", "beta11", "beta22", "mu1", "mu2", "alfa11", "alfa22"])
+    mad["mtbl", "mflw"] = mad.twiss(
+        sequence=mad.seq, implicit=True, nslice=10, save="'atbody'"
+    )
+    cols = mad.quote_strings(
+        ["name", "s", "beta11", "beta22", "mu1", "mu2", "alfa11", "alfa22"]
+    )
     mad.mtbl.write("'twiss_py.tfs'", cols)
-    
-    for x in mad.seq: # If an object is iterable, it is possible to loop over it
+
+    for x in mad.seq:  # If an object is iterable, it is possible to loop over it
         print(x.name, x.kind)
-    
+
     plt.plot(mad.mtbl.s, mad.mtbl.beta11)
     plt.show()
 

--- a/examples/ex-fodo/ex-fodos.py
+++ b/examples/ex-fodo/ex-fodos.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 
 from pymadng import MAD
 
-orginal_dir = os.getcwd()
+original_dir = os.getcwd()
 os.chdir(os.path.dirname(os.path.realpath(__file__)))
 
 # The typical way to communicate with MAD-NG is to use the send and recv methods.
@@ -51,4 +51,4 @@ with MAD() as mad:
     plt.plot(mad.mtbl.s, mad.mtbl.beta11)
     plt.show()
 
-os.chdir(orginal_dir)
+os.chdir(original_dir)

--- a/examples/ex-lhc-couplingLocal/ex-lhc-couplingLocal.py
+++ b/examples/ex-lhc-couplingLocal/ex-lhc-couplingLocal.py
@@ -12,7 +12,7 @@ import matplotlib.pyplot as plt
 
 from pymadng import MAD
 
-orginal_dir = os.getcwd()
+original_dir = os.getcwd()
 os.chdir(os.path.dirname(os.path.realpath(__file__)))
 
 
@@ -98,4 +98,4 @@ with MAD() as mad:
     t1 = time.time()
     print("Matching time: " + str(t1 - t0) + "s")
 
-os.chdir(orginal_dir)
+os.chdir(original_dir)

--- a/examples/ex-lhc-couplingLocal/ex-lhc-couplingLocal.py
+++ b/examples/ex-lhc-couplingLocal/ex-lhc-couplingLocal.py
@@ -1,9 +1,10 @@
 """
 This script demonstrates the usage of the MAD class to perform a local coupling correction in the LHC.
 
-The aim of this script is demonstrate a combination of pythonic and MAD-NG syntax. 
-Also, it demonstrates how you can retrieve data from MAD-NG and plot it in real-time, as it is being calculated, preventing the need to store it in memory. 
+The aim of this script is demonstrate a combination of pythonic and MAD-NG syntax.
+Also, it demonstrates how you can retrieve data from MAD-NG and plot it in real-time, as it is being calculated, preventing the need to store it in memory.
 """
+
 import os
 import time
 
@@ -39,9 +40,7 @@ with MAD() as mad:
     kqsx3_r2 = +0.0015
     """)
     t0 = time.time()
-    mad["tbl", "flw"] = mad.twiss(sequence=mad.lhcb1, method=4)
-    # plt.plot(mad.tbl.s, mad.tbl.beta11)
-    # plt.show()
+    mad["tbl", "flw"] = mad.twiss(sequence=mad.lhcb1)
     mad.tbl.write("'before_tune_correction_n'")
 
     print("Values before matching")
@@ -52,8 +51,8 @@ with MAD() as mad:
     expr1 = \\t, s -> t.q1 - 62.30980
     expr2 = \\t, s -> t.q2 - 60.32154
     function twiss_and_send()
-        local mtbl, mflow = twiss {sequence=lhcb1, method=4}
-        py:send({mtbl.s, mtbl.beta11})
+        local mtbl, mflow = twiss {sequence=lhcb1}
+        py:send({mtbl.s, mtbl.beta11}, true) -- True means that the data table is sent as a shallow copy
         return mtbl, mflow
     end
     """)
@@ -94,9 +93,9 @@ with MAD() as mad:
     print("dQx.b1=", mad.MADX.dqx_b1)
     print("dQy.b1=", mad.MADX.dqy_b1)
 
-    mad.twiss("tbl", sequence=mad.lhcb1, method=4, chrom=True)
+    mad.twiss("tbl", sequence=mad.lhcb1)
     mad.tbl.write("'after_tune_correction_n'")
     t1 = time.time()
-    print("pre-tracking time: " + str(t1 - t0) + "s")
+    print("Matching time: " + str(t1 - t0) + "s")
 
 os.chdir(orginal_dir)

--- a/examples/ex-managing-refs/ex-managing-refs.py
+++ b/examples/ex-managing-refs/ex-managing-refs.py
@@ -17,7 +17,7 @@ mad.seq.beam = mad.beam()
 
 
 # Only one thing is returned from the twiss, a reference (Nothing in python is ever received from MAD after telling MAD-NG to execute)
-twissrtrn = mad.twiss(sequence=mad.seq, method=4)
+twissrtrn = mad.twiss(sequence=mad.seq)
 
 # Any high level MAD-NG function will create a reference
 mad.MAD.gmath.reim(1.42 + 0.62j)
@@ -27,7 +27,10 @@ mad["mtbl", "mflw"] = twissrtrn
 
 # mtbl and mflow correctly stored!
 print(mad.mtbl)
-print(mad.mflw)
+print(mad.mflw[0])
+mad.send(
+    "print(mtbl, mflw[1])"
+)  # This will print the table and the particle stored in mflw[1] (lua table)
 
 myMatrix = mad.MAD.matrix(4).seq()  # Create 4x4 matrix
 

--- a/examples/ex-managing-refs/ex-managing-refs.py
+++ b/examples/ex-managing-refs/ex-managing-refs.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from pymadng import MAD
 
-orginal_dir = os.getcwd()
+original_dir = os.getcwd()
 os.chdir(os.path.dirname(os.path.realpath(__file__)))
 
 mad = MAD()  # Not being in context manager makes not difference.
@@ -42,4 +42,4 @@ myMatrix = myMatrix.eval()  # Store the matrix permanantly
 mad["myMatrix"] = mad.MAD.matrix(4).seq()
 print(mad.myMatrix, np.all(myMatrix == mad.myMatrix))
 
-os.chdir(orginal_dir)
+os.chdir(original_dir)

--- a/examples/ex-ps-twiss/ex-ps-twiss.py
+++ b/examples/ex-ps-twiss/ex-ps-twiss.py
@@ -1,4 +1,5 @@
-import os, time, pandas
+import os
+
 from pymadng import MAD
 
 orginal_dir = os.getcwd()
@@ -8,10 +9,10 @@ with MAD(debug=False) as mad:
     mad["psbeam"] = mad.beam(particle="'proton'", pc=2.794987)
     mad.MADX.BEAM = mad.psbeam
     mad.MADX.BRHO = mad.psbeam.brho
-    mad.MADX.load(f"'ps_unset_vars.mad'")
-    mad.MADX.load(f"'ps_mu.seq'")
-    mad.MADX.load(f"'ps_ss.seq'")
-    mad.MADX.load(f"'ps_fb_lhc.str'")
+    mad.MADX.load("'ps_unset_vars.mad'")
+    mad.MADX.load("'ps_mu.seq'")
+    mad.MADX.load("'ps_ss.seq'")
+    mad.MADX.load("'ps_fb_lhc.str'")
 
     mad.load("MADX", "ps")
     mad.ps.beam = mad.psbeam
@@ -21,7 +22,7 @@ with MAD(debug=False) as mad:
         mad.quote_strings(["name", "kind", "s", "l", "angle", "x", "y", "z", "theta"]),
         )
 
-    mad["mtbl", "mflw"] = mad.twiss(sequence=mad.ps, method=6, nslice=3, chrom=True)
+    mad["mtbl", "mflw"] = mad.twiss(sequence=mad.ps, method=6, nslice=3)
 
     mad.load("MAD.gphys", "melmcol")
     #Add element properties as columns
@@ -39,13 +40,16 @@ with MAD(debug=False) as mad:
         )
     
     df = mad.mtbl.to_df()
-    print(df)
     try:
         import tfs
+        assert type(df) is tfs.TfsDataFrame
+        print("tfs-pandas installed, so the header is stored in headers")
+        print(df.headers)
     except ImportError:
         print("tfs-pandas not installed, so the header is stored in attrs instead of headers")
         print(df.attrs)
 
+    print(df)
     print(mad.srv.to_df())
 
 os.chdir(orginal_dir)

--- a/examples/ex-ps-twiss/ex-ps-twiss.py
+++ b/examples/ex-ps-twiss/ex-ps-twiss.py
@@ -2,7 +2,7 @@ import os
 
 from pymadng import MAD
 
-orginal_dir = os.getcwd()
+original_dir = os.getcwd()
 os.chdir(os.path.dirname(os.path.realpath(__file__)))
 
 with MAD(debug=False) as mad:
@@ -52,4 +52,4 @@ with MAD(debug=False) as mad:
     print(df)
     print(mad.srv.to_df())
 
-os.chdir(orginal_dir)
+os.chdir(original_dir)

--- a/examples/ex-recv-lhc/ex-defexpr.py
+++ b/examples/ex-recv-lhc/ex-defexpr.py
@@ -1,5 +1,8 @@
+import os
+import time
+
 from pymadng import MAD
-import time, os
+
 current_dir = os.path.dirname(os.path.realpath(__file__)) + "/"
 
 mad = MAD()
@@ -42,46 +45,51 @@ end
 """)
 
 t0 = time.time()
-mad.LHC_load ()
-mad.recv() #done
+mad.LHC_load()
+mad.recv()  # done
 t1 = time.time()
-print("Load time:", t1-t0, " sec\n")
+print("Load time:", t1 - t0, " sec\n")
 
 t0 = time.time()
 mad.reg_expr("MADX", mad.MADX)
-mad.send("py:send('done')").recv() # reg_expr is recursive
+mad.send("py:send('done')").recv()  # reg_expr is recursive
 t1 = time.time()
-print("reg_expr time:", t1-t0, " sec\n")
+print("reg_expr time:", t1 - t0, " sec\n")
 
-mad.send("for i=1,#expr do expr[i]() end") #So that warnings are performed here and do no affect timing
+mad.send(
+    "for i=1,#expr do expr[i]() end"
+)  # So that warnings are performed here and do no affect timing
 
 
-#Methods of evaluation:
+# Methods of evaluation:
 t0 = time.time()
 mad.send("py:send(#expr)")
 for i in range(mad.recv()):
-    mad.send(f"py:send(expr[{i+1}]())").recv()
+    mad.send(f"py:send(expr[{i + 1}]())").recv(f"expr[{i + 1}]()")
 t1 = time.time()
-print("eval time method 1:", t1-t0, " sec")
+print("eval time method 1:", t1 - t0, " sec")
 
 t0 = time.time()
 mad.send("len = #expr py:send(len) for i=1,len do py:send(expr[i]()) end")
 for i in range(mad.recv()):
-    mad.recv()
+    mad.recv(f"expr[{i + 1}]()")
 t1 = time.time()
-print("eval time method 2:", t1-t0, " sec")
+print("eval time method 2:", t1 - t0, " sec")
 
 t0 = time.time()
 mad.send("py:send(#expr)")
-exprList1 = [mad.send(f"py:send(expr[{i+1}]())").recv() for i in range(mad.recv())]
+exprList1 = [
+    mad.send(f"py:send(expr[{i + 1}]())").recv(f"expr[{i + 1}]()")
+    for i in range(mad.recv())
+]
 t1 = time.time()
-print("eval time method 3:", t1-t0, " sec")
+print("eval time method 3:", t1 - t0, " sec")
 
 t0 = time.time()
 mad.send("len = #expr py:send(len) for i=1,len do py:send(expr[i]()) end")
-exprList2 = [mad.recv() for i in range(mad.recv())]
+exprList2 = [mad.recv(f"expr[{i + 1}]()") for i in range(mad.recv())]
 t1 = time.time()
-print("eval time method 4:", t1-t0, " sec\n")
+print("eval time method 4:", t1 - t0, " sec\n")
 
 
 print("sanity check", exprList1 == exprList2, len(exprList1))
@@ -97,7 +105,7 @@ end
 """)
 nameList = [mad.recv() for _ in range(mad.recv())]
 t1 = time.time()
-print("time to retrieve every element name in lhcb1 sequence", t1-t0, "sec")
+print("time to retrieve every element name in lhcb1 sequence", t1 - t0, "sec")
 print(len(nameList))
 
 
@@ -110,7 +118,7 @@ for i, elm, spos, len in lhcb2:iter() do
 end
 py:send(lhcb2_tbl)
 """)
-nameList = mad.recv()
+nameList = mad.recv("lhcb2_tbl")
 t1 = time.time()
-print("time to retrieve every element name in lhcb2 sequence", t1-t0, "sec")
+print("time to retrieve every element name in lhcb2 sequence", t1 - t0, "sec")
 print(len(nameList))

--- a/examples/runall.py
+++ b/examples/runall.py
@@ -2,9 +2,9 @@ import os
 current_dir = os.path.dirname(os.path.realpath(__file__)) + "/"
 
 filenames = [
-    "ex-benchmark-and-fork/ex-benchmark-and-fork.py", "ex-fodo/ex-fodos.py", "ex-lhc-couplingLocal/lhc-couplingLocal.py",
+    "ex-benchmark-and-fork/ex-benchmark-and-fork.py", "ex-fodo/ex-fodos.py", "ex-lhc-couplingLocal/ex-lhc-couplingLocal.py",
     "ex-managing-refs/ex-managing-refs.py", "ex-LowLevel/ex-send-multypes.py", "ex-LowLevel/ex-send-recv.py", 
-    "ex-ps-twiss/ps-twiss.py", "ex-recv-lhc/ex-defexpr.py"
+    "ex-ps-twiss/ex-ps-twiss.py", "ex-recv-lhc/ex-defexpr.py"
     ]
 for name in filenames:
     print(name)

--- a/src/pymadng/__init__.py
+++ b/src/pymadng/__init__.py
@@ -1,7 +1,7 @@
 from .madp_object import MAD
 
 __title__ = "pymadng"
-__version__ = "0.6.3"
+__version__ = "0.7.0"
 
 __summary__ = "Python interface to MAD-NG running as subprocess"
 __uri__ = "https://github.com/MethodicalAcceleratorDesign/MAD-NG.py"

--- a/src/pymadng/madp_classes.py
+++ b/src/pymadng/madp_classes.py
@@ -127,7 +127,6 @@ class high_level_mad_ref(mad_ref):
             f"Parent: {self._parent}, "
             f"Process: {repr(self._mad)}, "
             f"Type: {type(self).__name__})>"
-            f"Evaluated Value: {self.eval()}>"
         )
 
     def __dir__(self) -> Iterable[str]:

--- a/src/pymadng/madp_classes.py
+++ b/src/pymadng/madp_classes.py
@@ -99,7 +99,7 @@ class high_level_mad_ref(mad_ref):
         Returns:
             str: The string representation of the MAD-NG reference.
         """
-        val = self._mad.recv_vars(self._name)
+        val = self._mad.recv_vars(self._name, shallow_copy=True)
         if isinstance(val, high_level_mad_ref):
             return repr(val)
         else:
@@ -112,7 +112,7 @@ class high_level_mad_ref(mad_ref):
         Returns:
             Any: The evaluated value of the reference in MAD-NG.
         """
-        return self._mad.recv_vars(self._name)
+        return self._mad.recv_vars(self._name, shallow_copy=True)
 
     def __repr__(self):
         """
@@ -127,6 +127,7 @@ class high_level_mad_ref(mad_ref):
             f"Parent: {self._parent}, "
             f"Process: {repr(self._mad)}, "
             f"Type: {type(self).__name__})>"
+            f"Evaluated Value: {self.eval()}>"
         )
 
     def __dir__(self) -> Iterable[str]:
@@ -136,7 +137,7 @@ class high_level_mad_ref(mad_ref):
         self._mad.protected_send(f"""
     local modList={{}}; local i = 1;
     for modname, mod in pairs({name}) do modList[i] = modname; i = i + 1; end
-    {self._mad.py_name}:send(modList)
+    {self._mad.py_name}:send(modList, true)
     """)
         return [x for x in self._mad.recv() if isinstance(x, str) and x[0] != "_"]
 
@@ -164,10 +165,10 @@ class high_level_mad_object(high_level_mad_ref):
     def __dir__(self) -> Iterable[str]:
         if not self._mad.ipython_use_jedi:
             self._mad.protected_send(
-                f"{self._mad.py_name}:send({self._name}:get_varkeys(MAD.object))"
+                f"{self._mad.py_name}:send({self._name}:get_varkeys(MAD.object), true)"
             )
         varnames = self._mad.protected_variable_retrieval(
-            f"{self._name}:get_varkeys(MAD.object, false)"
+            f"{self._name}:get_varkeys(MAD.object, false)", shallow_copy=True
         )
 
         if not self._mad.ipython_use_jedi:
@@ -189,9 +190,6 @@ class high_level_mad_object(high_level_mad_ref):
         return last_obj
 
     def __iter__(self):
-        self._mad.send(f"{self._mad.py_name}:send({self._name}:is_instanceOf(sequence))")
-        is_seq = self._mad.recv()
-        assert is_seq, "Iteration is only supported for sequences for now"
         self._iterindex = -1
         return self
 
@@ -238,7 +236,7 @@ class high_level_mad_object(high_level_mad_ref):
             f"""
 local is_vector, is_number, is_string in MAD.typeid
 local colnames = {py_name}:recv() or {obj_name}:colnames() -- Get the column names 
-{py_name}:send(colnames)               -- Send the column names
+{py_name}:send(colnames, true)               -- Send the column names
 
 -- Loop through all the column names and send them with their data
 for i, colname in ipairs(colnames) do
@@ -263,14 +261,14 @@ for i, colname in ipairs(colnames) do
     col = tbl
   end
 
-  {py_name}:send(col) -- Send the column data
+  {py_name}:send(col, true) -- Send the column data
 end
 
 local header = {obj_name}.header -- Get the header names
-{py_name}:send(header)           -- Send the header names
+{py_name}:send(header, true)           -- Send the header names
 
 for i, attr in ipairs(header) do 
-  {py_name}:send({obj_name}[attr]) -- Send the header data
+  {py_name}:send({obj_name}[attr], true) -- Send the header data
 end
 """
         )

--- a/src/pymadng/madp_object.py
+++ b/src/pymadng/madp_object.py
@@ -291,17 +291,18 @@ _last = {}
         """
         self.__process.send_vars(**vars)
 
-    def recv_vars(self, *names: str) -> Any:
+    def recv_vars(self, *names: str, shallow_copy: bool = False) -> Any:
         """
         Retrieve one or more variables from MAD-NG.
 
         Args:
             *names (str): The names of the variables to be fetched from MAD-NG.
+            shallow_copy (bool, optional): If True, returns a shallow copy of the variables.
 
         Returns:
             The retrieved variable value or a tuple of values if multiple names are provided.
         """
-        return self.__process.recv_vars(*names)
+        return self.__process.recv_vars(*names, shallow_copy=shallow_copy)
 
     # -------------------------------------------------------------------------------------------------------------#
 
@@ -471,7 +472,7 @@ _last = {}
     def __dir__(self) -> Iterable[str]:
         pyObjs = [x for x in super(MAD, self).__dir__() if x[0] != "_"]
         pyObjs.extend(self.globals())
-        pyObjs.extend(dir(self.recv_vars("_G")))
+        pyObjs.extend(dir(self.recv_vars("_G", shallow_copy=True)))
         return pyObjs
 
     def globals(self) -> list[str]:
@@ -481,7 +482,7 @@ _last = {}
         Returns:
             list[str]: A list containing the names of global variables.
         """
-        return dir(self.__process.recv_vars(f"{self.py_name}._env"))
+        return dir(self.__process.recv_vars(f"{self.py_name}._env", shallow_copy=True))
 
     def history(self) -> str:
         """

--- a/src/pymadng/madp_object.py
+++ b/src/pymadng/madp_object.py
@@ -68,7 +68,7 @@ class MAD(object):
         raise_on_madng_error: bool = True,
         debug: bool = False,
         stdout: TextIO | str | Path = None,
-        redirect_sterr: bool = False,
+        redirect_stderr: bool = False,
         num_temp_vars: int = 8,
         ipython_use_jedi: bool = False,
     ):
@@ -84,7 +84,7 @@ class MAD(object):
             raise_on_madng_error (bool, optional): If True, raises errors from MAD-NG immediately.
             debug (bool, optional): If True, enables detailed debugging output.
             stdout (TextIO | str | Path, optional): Destination for MAD-NG's standard output.
-            redirect_sterr (bool, optional): If True, redirects stderr to stdout.
+            redirect_stderr (bool, optional): If True, redirects stderr to stdout.
             num_temp_vars (int, optional): Maximum number of temporary variables to track.
             ipython_use_jedi (bool, optional): If True, allows IPython to use jedi for autocompletion.
         """
@@ -96,7 +96,7 @@ class MAD(object):
             raise_on_madng_error=raise_on_madng_error,
             debug=debug,
             stdout=stdout,
-            redirect_sterr=redirect_sterr,
+            redirect_stderr=redirect_stderr,
         )
         self.__process.ipython_use_jedi = ipython_use_jedi
         self.__process.last_counter = last_counter(num_temp_vars)

--- a/src/pymadng/madp_pymad.py
+++ b/src/pymadng/madp_pymad.py
@@ -888,7 +888,7 @@ def recv_dict(self: mad_process) -> dict:
         if key is None:  # End of dictionary
             break
         if isinstance(key, np.int32):
-            key = int(key) - 1  # Convert MAD-NG's 1-based index to Python's 0-based index
+            key = int(key)
         value = self.recv(varname and f"{varname}['{key}']")
         dct[key] = value
     self.varname = varname  # reset

--- a/src/pymadng/madp_pymad.py
+++ b/src/pymadng/madp_pymad.py
@@ -224,7 +224,7 @@ class mad_process:
         Returns:
             The value of the variable.
         """
-        shallow_copy = "true" if shallow_copy else "false"
+        shallow_copy = str(shallow_copy).lower()
         if self.raise_on_madng_error:
             return self.send(f"py:send({name}, {shallow_copy})").recv(name)
         self.send(

--- a/src/pymadng/madp_pymad.py
+++ b/src/pymadng/madp_pymad.py
@@ -42,7 +42,7 @@ class mad_process:
         raise_on_madng_error: bool = True,
         debug: bool = False,
         stdout: str | Path | TextIO = None,
-        redirect_sterr: bool = False,
+        redirect_stderr: bool = False,
     ) -> None:
         self.py_name = py_name
 
@@ -76,7 +76,7 @@ class mad_process:
             ) from e
 
         # Redirect stderr to stdout, if specified
-        if redirect_sterr:
+        if redirect_stderr:
             stderr = stdout
         else:
             stderr = sys.stderr.fileno()

--- a/tests/inputs/example.log
+++ b/tests/inputs/example.log
@@ -18,13 +18,13 @@ track = MAD.track
 match = MAD.match
 ] 194 bytes
 ***pymad.recv: binary data 4 bytes
-***pymad.recv: [py:__err(true):send(MAD):__err(false)] 37 bytes
+***pymad.recv: [py:__err(true):send(MAD, false):__err(false)] 44 bytes
 ***pymad.send: [ref_] 4 bytes
 ***pymad.recv: binary data 4 bytes
-***pymad.recv: [py:__err(true):send(MAD['env']):__err(false)] 44 bytes
+***pymad.recv: [py:__err(true):send(MAD['env'], false):__err(false)] 51 bytes
 ***pymad.send: [ref_] 4 bytes
 ***pymad.recv: binary data 4 bytes
-***pymad.recv: [py:__err(true):send(MAD['env']['version']):__err(false)] 55 bytes
+***pymad.recv: [py:__err(true):send(MAD['env']['version'], false):__err(false)] 62 bytes
 ***pymad.send: [str_] 4 bytes
 ***pymad.send: binary data 4 bytes
 ***pymad.send: [1.1.2] 5 bytes

--- a/tests/inputs/example.log
+++ b/tests/inputs/example.log
@@ -27,7 +27,7 @@ match = MAD.match
 ***pymad.recv: [py:__err(true):send(MAD['env']['version'], false):__err(false)] 62 bytes
 ***pymad.send: [str_] 4 bytes
 ***pymad.send: binary data 4 bytes
-***pymad.send: [1.1.2] 5 bytes
+***pymad.send: [1.1.3] 5 bytes
 ***pymad.recv: binary data 4 bytes
 ***pymad.recv: [
 function __mklast__ (a, b, ...)

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -15,7 +15,7 @@ class TestExecution(unittest.TestCase):
             self.assertEqual(a, 50)
 
     def test_err(self):
-        with MAD(stdout="/dev/null", redirect_sterr=True) as mad:
+        with MAD(stdout="/dev/null", redirect_stderr=True) as mad:
             mad.send("py:__err(true)")  
             mad.send("1+1") #Load error
             self.assertRaises(RuntimeError, mad.recv)
@@ -47,7 +47,7 @@ Like So.]])"""
             self.assertEqual(mad.recv(), initString * 2)
 
     def test_protected_send(self):
-        with MAD(stdout="/dev/null", redirect_sterr=True, raise_on_madng_error=False) as mad:
+        with MAD(stdout="/dev/null", redirect_stderr=True, raise_on_madng_error=False) as mad:
             mad.send("py:send('hello world'); a = nil/2")
             self.assertEqual(mad.recv(), "hello world") # python should not crash
             mad.send("py:send(1)")

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -54,7 +54,7 @@ class TestDebug(unittest.TestCase):
             self.assertFalse("***pymad.run:" in file_text)
 
         # Run debug with stderr redirection
-        with MAD(stdout=self.test_log1, redirect_sterr=True) as mad:
+        with MAD(stdout=self.test_log1, redirect_stderr=True) as mad:
             mad.psend("a = nil/2")
             # receive the error before closing the pipe
             self.assertRaises(RuntimeError, mad.recv) 

--- a/tests/test_io_and_loading.py
+++ b/tests/test_io_and_loading.py
@@ -36,7 +36,7 @@ class TestLoad(unittest.TestCase):
             a = matrix(4, 5):seq()
             b = cmatrix(2, 3):seq()
             """)
-        with MAD(stdout="/dev/null", redirect_sterr=True) as mad:
+        with MAD(stdout="/dev/null", redirect_stderr=True) as mad:
             mad.loadfile("test.mad")
             self.assertIsNone(mad.matrix)
             self.assertTrue(np.all(mad.a == self.a))

--- a/tests/test_misc_types.py
+++ b/tests/test_misc_types.py
@@ -37,10 +37,11 @@ class TestRngs(unittest.TestCase):
             py:send(irng)
             py:send(rng)
             py:send(lrng)
-            py:send(irng:totable())
-            py:send(rng:totable())
-            py:send(lrng:totable())
+            py:send(irng:totable(), true)
+            py:send(rng:totable(), true)
+            py:send(lrng:totable(), true)
             """)
+
             self.assertEqual(mad.recv(), range(3  , 12  , 2)) #MAD is inclusive, python is exclusive (on stop)
             self.assertTrue (np.allclose(mad.recv(), np.linspace(3.5, 21.4, 12)))
             self.assertTrue (np.allclose(mad.recv(), np.geomspace(1, 20, 20)))
@@ -54,9 +55,9 @@ class TestRngs(unittest.TestCase):
             irng = py:recv() + 1 
             rng  = py:recv() + 2
             lrng = py:recv()
-            py:send(irng:totable())
-            py:send(rng:totable())
-            py:send(lrng:totable())
+            py:send(irng:totable(), true)
+            py:send(rng:totable(), true)
+            py:send(lrng:totable(), true)
             """)
             mad.send(range(3, 10, 1))
             mad.send_range(3.5, 21.4, 14)
@@ -157,8 +158,8 @@ class TestTPSA(unittest.TestCase):
             for i = 1, #tab do
                 index_part[i] = tab[i]
             end
-            py:send(tab)
-            py:send(index_part)
+            py:send(tab, true)
+            py:send(index_part, true)
             """)
             monos = np.asarray([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1], [2, 0, 0], [1, 1, 0]], dtype=np.uint8)
             coefficients = [11, 6, 4, 2, 1, 1]
@@ -184,8 +185,8 @@ class TestTPSA(unittest.TestCase):
             for i = 1, #tab do
                 index_part[i] = tab[i]
             end
-            py:send(tab)
-            py:send(index_part)
+            py:send(tab, true)
+            py:send(index_part, true)
             """)
             monos = np.asarray([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1], [2, 0, 0], [1, 1, 0]], dtype=np.uint8)
             coefficients = [10+6j, 2+14j, 2+9j, 2+4j, -3+4j, -3+4j]

--- a/tests/test_misc_types.py
+++ b/tests/test_misc_types.py
@@ -172,7 +172,7 @@ class TestTPSA(unittest.TestCase):
             self.assertEqual(index_part, expected_index)
             for key, value in whole_tab.items():
                 if isinstance(key, int):
-                    self.assertTrue(value == expected_index[key])
+                    self.assertTrue(value == expected_index[key-1])
                 else:
                     idx = expected_index.index(key)
                     self.assertTrue(whole_tab[key] == coefficients[idx])
@@ -199,7 +199,7 @@ class TestTPSA(unittest.TestCase):
             self.assertEqual(index_part, expected_index)
             for key, value in whole_tab.items():
                 if isinstance(key, int):
-                    self.assertTrue(value == expected_index[key])
+                    self.assertTrue(value == expected_index[key-1])
                 else:
                     idx = expected_index.index(key)
                     self.assertTrue(whole_tab[key] == coefficients[idx])

--- a/tests/test_misc_types.py
+++ b/tests/test_misc_types.py
@@ -169,11 +169,12 @@ class TestTPSA(unittest.TestCase):
             whole_tab = mad.recv("tab")
             index_part = mad.recv("index_part")
             self.assertEqual(index_part, expected_index)
-            for i in range(len(whole_tab)):
-                self.assertTrue(whole_tab[i] == expected_index[i])
-            
-            for i, key in enumerate(expected_index):
-                self.assertTrue(whole_tab[key] == coefficients[i])
+            for key, value in whole_tab.items():
+                if isinstance(key, int):
+                    self.assertTrue(value == expected_index[key])
+                else:
+                    idx = expected_index.index(key)
+                    self.assertTrue(whole_tab[key] == coefficients[idx])
     
     def test_send_ctpsa(self):
         with MAD() as mad:
@@ -195,10 +196,12 @@ class TestTPSA(unittest.TestCase):
             whole_tab = mad.recv("tab")
             index_part = mad.recv("index_part")
             self.assertEqual(index_part, expected_index)
-            for i in range(len(whole_tab)):
-                self.assertTrue(whole_tab[i] == expected_index[i])
-            for i, key in enumerate(expected_index):
-                self.assertTrue(whole_tab[key] == coefficients[i])
+            for key, value in whole_tab.items():
+                if isinstance(key, int):
+                    self.assertTrue(value == expected_index[key])
+                else:
+                    idx = expected_index.index(key)
+                    self.assertTrue(whole_tab[key] == coefficients[idx])
 
     def test_send_recv_damap(self):
         with MAD() as mad:

--- a/tests/test_numeric_types.py
+++ b/tests/test_numeric_types.py
@@ -20,7 +20,7 @@ class TestList(unittest.TestCase):
     def test_send_recv_wref(self):
         with MAD() as mad:
             mad.send("""
-            list = {MAD.object "a" {a = 2}, MAD.object "b" {b = 2}}
+            list = {MAD.object "a" {a = 2}, MAD.object "b" {b = 6}}
             list2 = {1, 2, 3, 4, 5, a = 10, b = 3, c = 4}
             py:send(list)
             py:send(list2)
@@ -28,12 +28,13 @@ class TestList(unittest.TestCase):
             list1 = mad.recv("list")
             list2 = mad.recv("list2")
             self.assertEqual(len(list1), 2)
-            self.assertEqual([x for x in list2], [1, 2, 3, 4, 5])
-            self.assertEqual(list2["a"], 10)
-            self.assertEqual(list2["b"], 3)
-            self.assertEqual(list2["c"], 4)
+            
+            python_dict = {0: 1, 1: 2, 2: 3, 3: 4, 4: 5, "a": 10, "b": 3, "c": 4}
+            self.assertEqual(list2.keys(), python_dict.keys())
+            self.assertEqual(sorted(list2.values()), sorted(python_dict.values()))
+
             self.assertEqual(list1[0].a, 2)
-            self.assertEqual(list1[1].b, 2)
+            self.assertEqual(list1[1].b, 6)
 
 class TestNums(unittest.TestCase):
     eps = 2**-52

--- a/tests/test_numeric_types.py
+++ b/tests/test_numeric_types.py
@@ -7,7 +7,7 @@ class TestList(unittest.TestCase):
         with MAD() as mad:
             myList = [[1, 2, 3, 4, 5, 6, 7, 8, 9]] * 2
             mad.send("""
-            local list = py:recv()
+            list = py:recv()
             list[1][1] = 10
             list[2][1] = 10
             py:send(list)
@@ -15,7 +15,10 @@ class TestList(unittest.TestCase):
             mad.send(myList)
             myList[0][0] = 10
             myList[1][0] = 10
-            self.assertEqual(mad.recv(), myList)
+            mad_list = mad.recv("list")
+            for i, inner_list in enumerate(mad_list):
+                for j, val in enumerate(inner_list):
+                    self.assertEqual(val, myList[i][j], f"Mismatch at index [{i}][{j}]: {val} != {myList[i][j]}")
 
     def test_send_recv_wref(self):
         with MAD() as mad:
@@ -30,8 +33,8 @@ class TestList(unittest.TestCase):
             self.assertEqual(len(list1), 2)
             
             python_dict = {0: 1, 1: 2, 2: 3, 3: 4, 4: 5, "a": 10, "b": 3, "c": 4}
-            self.assertEqual(list2.keys(), python_dict.keys())
-            self.assertEqual(sorted(list2.values()), sorted(python_dict.values()))
+            self.assertEqual(list2.eval().keys(), python_dict.keys())
+            self.assertEqual(sorted(list2.eval().values()), sorted(python_dict.values()))
 
             self.assertEqual(list1[0].a, 2)
             self.assertEqual(list1[1].b, 6)

--- a/tests/test_numeric_types.py
+++ b/tests/test_numeric_types.py
@@ -22,17 +22,17 @@ class TestList(unittest.TestCase):
 
     def test_send_recv_wref(self):
         with MAD() as mad:
+            python_dict = {1: 1, 2: 2, 3: 3, 4: 4, 5: 5, "a": 10, "b": 3, "c": 4}
             mad.send("""
             list = {MAD.object "a" {a = 2}, MAD.object "b" {b = 6}}
-            list2 = {1, 2, 3, 4, 5, a = 10, b = 3, c = 4}
+            list2 = py:recv()
             py:send(list)
             py:send(list2)
-            """)
+            """).send(python_dict)
             list1 = mad.recv("list")
             list2 = mad.recv("list2")
             self.assertEqual(len(list1), 2)
             
-            python_dict = {0: 1, 1: 2, 2: 3, 3: 4, 4: 5, "a": 10, "b": 3, "c": 4}
             self.assertEqual(list2.eval().keys(), python_dict.keys())
             self.assertEqual(sorted(list2.eval().values()), sorted(python_dict.values()))
 

--- a/tests/test_object_wrapping.py
+++ b/tests/test_object_wrapping.py
@@ -24,13 +24,13 @@ class TestGetSet(unittest.TestCase):
             self.assertEqual(qd._name, "qd")
             self.assertEqual(qd._parent, None)
             self.assertEqual(qd._mad, mad._MAD__process)
-            self.assertEqual(qd.knl, [0, 0.25])
+            self.assertEqual(qd.knl.eval(), [0, 0.25])
             self.assertEqual(qd.l, 1)
             self.assertRaises(AttributeError, lambda: qd.asdfg)
             self.assertRaises(KeyError, lambda: qd["asdfg"])
             self.assertRaises(IndexError, lambda: qd[1])
             self.assertTrue(isinstance(qf.qd, high_level_mad_ref))
-            self.assertEqual(qf.qd.knl, [0, 0.25])
+            self.assertEqual(qf.qd.knl.eval(), [0, 0.25])
             self.assertEqual(qf.qd.l, 1)
             self.assertEqual(qf.qd, qd)
 
@@ -40,12 +40,12 @@ class TestGetSet(unittest.TestCase):
                 if i % 2 != 0:
                     self.assertTrue(isinstance(objList[i].qd, high_level_mad_ref))
                     self.assertEqual(objList[i].qd._parent, f"objList[{i + 1}]")
-                    self.assertEqual(objList[i].qd.knl, [0, 0.25])
+                    self.assertEqual(objList[i].qd.knl.eval(), [0, 0.25])
                     self.assertEqual(objList[i].qd.l, 1)
                     self.assertEqual(objList[i].qd, qd)
 
                 else:
-                    self.assertEqual(objList[i].knl, [0, 0.25])
+                    self.assertEqual(objList[i].knl.eval(), [0, 0.25])
                     self.assertEqual(objList[i].l, 1)
                     self.assertEqual(objList[i], qd)
                 self.assertEqual(objList[i]._parent, "objList")
@@ -58,7 +58,7 @@ class TestGetSet(unittest.TestCase):
             self.assertEqual(mad.qd2._name, "qd2")
             self.assertEqual(mad.qd2._parent, None)
             self.assertEqual(mad.qd2._mad, mad._MAD__process)
-            self.assertEqual(mad.qd2.knl, [0, 0.25])
+            self.assertEqual(mad.qd2.knl.eval(), [0, 0.25])
             self.assertEqual(mad.qd2.l, 1)
             self.assertEqual(mad.qd2, mad.qd)
             mad["a", "b"] = mad.MAD.gmath.reim(9.75 + 1.5j)
@@ -79,7 +79,7 @@ class TestGetSet(unittest.TestCase):
             self.assertEqual(mad.a, 1)
             self.assertEqual(mad.b, 2.5)
             self.assertEqual(mad.c, "test")
-            self.assertEqual(mad.d, [1, 2, 3])
+            self.assertEqual(mad.d.eval(), [1, 2, 3])
 
     def test_recv_vars(self):
         with MAD() as mad:
@@ -88,7 +88,7 @@ class TestGetSet(unittest.TestCase):
             self.assertEqual(a, 1)
             self.assertEqual(b, 2.5)
             self.assertEqual(c, "test")
-            self.assertEqual(d, [1, 2, 3])
+            self.assertEqual(d.eval(), [1, 2, 3])
 
     def test_quote_strings(self):
         with MAD() as mad:
@@ -122,7 +122,7 @@ class TestObjFun(unittest.TestCase):
             self.assertEqual(mad.qd._name, "qd")
             self.assertEqual(mad.qd._parent, None)
             self.assertEqual(mad.qd._mad, mad._MAD__process)
-            self.assertEqual(mad.qd.knl, [0, 0.25])
+            self.assertEqual(mad.qd.knl.eval(), [0, 0.25])
             self.assertEqual(mad.qd.l, 1)
 
             sdc = sd
@@ -131,14 +131,14 @@ class TestObjFun(unittest.TestCase):
             self.assertEqual(mad.sd._name, "sd")
             self.assertEqual(mad.sd._parent, None)
             self.assertEqual(mad.sd._mad, mad._MAD__process)
-            self.assertEqual(mad.sd.knl, [0, 0.25, 0.5])
+            self.assertEqual(mad.sd.knl.eval(), [0, 0.25, 0.5])
             self.assertEqual(mad.sd.l, 1)
 
             # Reference counting
             qd = mad.quadrupole(knl=[0, 0.3], l=1)
             self.assertEqual(sdc._name, "_last[2]")
             self.assertEqual(qd._name, "_last[3]")
-            self.assertEqual(qd.knl, [0, 0.3])
+            self.assertEqual(qd.knl.eval(), [0, 0.3])
             qd = mad.quadrupole(knl=[0, 0.25], l=1)
             self.assertEqual(qd._name, "_last[1]")
 
@@ -225,7 +225,7 @@ class TestObjFun(unittest.TestCase):
       """)
         mad.MADX.load("'test.seq'")
         self.assertEqual(mad.MADX.qd.l, 1)
-        self.assertEqual(mad.MADX.qd.knl, [0, 0.25])
+        self.assertEqual(mad.MADX.qd.knl.eval(), [0, 0.25])
         os.remove("test.seq")
 
     def test_evaluate_in_madx_environment(self):
@@ -235,7 +235,7 @@ class TestObjFun(unittest.TestCase):
             """
             mad.evaluate_in_madx_environment(madx_code)
             self.assertEqual(mad.MADX.qd.l, 1)
-            self.assertEqual(mad.MADX.qd.knl, [0, 0.25])
+            self.assertEqual(mad.MADX.qd.knl.eval(), [0, 0.25])
 
 
 class TestOps(unittest.TestCase):
@@ -310,9 +310,9 @@ class TestArgsAndKwargs(unittest.TestCase):
                 opposite=False,
                 mat=mad.m1,
             )
-            self.assertEqual(sd.knl, [0, 0.25j, 1 + 1j])
+            self.assertEqual(sd.knl.eval(), [0, 0.25j, 1 + 1j])
             self.assertEqual(sd.l, 1)
-            self.assertEqual(sd.alist, [1, 2, 3, 5])
+            self.assertEqual(sd.alist.eval(), [1, 2, 3, 5])
             self.assertEqual(sd.abool, True)
             self.assertEqual(sd.opposite, False)
             self.assertTrue(np.all(sd.mat == np.arange(9).reshape((3, 3)) + 1))
@@ -417,7 +417,8 @@ test:write("test")
             df["complex"].tolist(), [1 + 2j, 2 + 3j, 3 + 4j, 4 + 5j, 5 + 6j]
         )
         self.assertEqual(df["boolean"].tolist(), [True, False, True, False, True])
-        self.assertEqual(df["list"].tolist(), [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]])
+        lists = [the_list.eval() for the_list in df["list"]]
+        self.assertEqual(lists, [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]])
         tbl = df["table"].tolist()
         for i in range(len(tbl)):
             lst = tbl[i]
@@ -483,7 +484,8 @@ class TestIteration(unittest.TestCase):
             for elem in mad.my_obj:
                 if elem.name == "qd":
                     self.assertEqual(elem.l, 1.6)
-                    self.assertEqual(elem.knl, [0, 0.25])
+                    for i in range(2):
+                        self.assertEqual(elem.knl[i], 0.25 if i == 1 else 0)
                 else:
                     self.assertEqual(elem.kind, "marker")
 

--- a/tests/test_object_wrapping.py
+++ b/tests/test_object_wrapping.py
@@ -15,7 +15,7 @@ from pymadng.madp_classes import high_level_mad_ref, mad_high_level_last_ref
 
 class TestGetSet(unittest.TestCase):
     def test_get(self):
-        with MAD(stdout="/dev/null", redirect_sterr=True) as mad:
+        with MAD(stdout="/dev/null", redirect_stderr=True) as mad:
             mad.load("element", "quadrupole")
             self.assertEqual(mad.asdfg, None)
             mad.send("""qd = quadrupole {knl={0,  0.25}, l = 1}""")
@@ -149,7 +149,7 @@ class TestObjFun(unittest.TestCase):
             self.assertEqual(mad.func_test(1)(2)(3), 7)
 
     def test_call_fail(self):
-        with MAD(stdout="/dev/null", redirect_sterr=True) as mad:
+        with MAD(stdout="/dev/null", redirect_stderr=True) as mad:
             mad.send("func_test = \\a-> \\b-> \\c-> 'a'+b")
             mad.func_test(1)(2)(3)
             self.assertRaises(RuntimeError, lambda: mad.recv())

--- a/tests/test_object_wrapping.py
+++ b/tests/test_object_wrapping.py
@@ -405,8 +405,8 @@ test:write("test")
         self.assertEqual(header["boolean"], True)
         self.assertEqual(header["list"], [1, 2, 3, 4, 5])
         tbl = getattr(df, headers)["table"]
-        self.assertEqual(tbl[0], 1)
-        self.assertEqual(tbl[1], 2)
+        self.assertEqual(tbl[1], 1)
+        self.assertEqual(tbl[2], 2)
         self.assertEqual(tbl["key"], "value")
         self.assertTrue(isinstance(tbl, dict))
 

--- a/tests/test_object_wrapping.py
+++ b/tests/test_object_wrapping.py
@@ -265,9 +265,9 @@ class TestOps(unittest.TestCase):
             )
             self.assertTrue(np.all(list(mad.MAD.matrix(10).seq()) == np.arange(1, 101)))
             self.assertTrue(np.all(mad.MAD.matrix(10).seq().eval() == pyMat))
-            self.assertEqual(np.sin(1), mad.math.sin(1).eval())
+            self.assertEqual(np.sin(1), mad.math['sin'](1).eval())
             self.assertAlmostEqual(
-                np.cos(0.5), mad.math.cos(0.5).eval(), None, None, 4e-16
+                np.cos(0.5), mad.math['cos'](0.5).eval(), None, None, 4e-16
             )
 
             # temp vars
@@ -405,8 +405,10 @@ test:write("test")
         self.assertEqual(header["boolean"], True)
         self.assertEqual(header["list"], [1, 2, 3, 4, 5])
         tbl = getattr(df, headers)["table"]
-        self.assertEqual([x for x in tbl], [1, 2])
+        self.assertEqual(tbl[0], 1)
+        self.assertEqual(tbl[1], 2)
         self.assertEqual(tbl["key"], "value")
+        self.assertTrue(isinstance(tbl, dict))
 
         self.assertEqual(df["string"].tolist(), ["a", "b", "c", "d", "e"])
         self.assertEqual(df["number"].tolist(), [1.1, 2.2, 3.3, 4.4, 5.5])
@@ -466,7 +468,7 @@ class TestEval(unittest.TestCase):
 
     def test_eval_class(self):
         with MAD() as mad:
-            result = mad.math.sqrt(2) + mad.math.log(10)
+            result = mad.math['sqrt'](2) + mad.math['log'](10)
             self.assertTrue(isinstance(result, mad_high_level_last_ref))
             self.assertEqual(result.eval(), math.sqrt(2) + math.log(10))
 


### PR DESCRIPTION
Breaking change - Now it forces all tables to be references. So lists that were previously transferred need the .eval(), which does a shallow copy. 


Updated documentation and examples. 

Closes #20 

Needs a release of MAD-NG to be merged.
