### PR TITLE
Bump MAD-NG to 1.1.12 and pymadng to 0.9.1

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -37,8 +37,8 @@ jobs:
     - name: Get MAD Binaries
       run: |
         mkdir src/pymadng/bin
-        curl https://madx.web.cern.ch/releases/madng/1.1/mad-linux-1.1.11 -o src/pymadng/bin/mad_Linux
-        curl https://madx.web.cern.ch/releases/madng/1.1/mad-macos-1.1.11 -o src/pymadng/bin/mad_Darwin
+        curl https://madx.web.cern.ch/releases/madng/1.1/mad-linux-1.1.12 -o src/pymadng/bin/mad_Linux
+        curl https://madx.web.cern.ch/releases/madng/1.1/mad-macos-1.1.12 -o src/pymadng/bin/mad_Darwin
         chmod +x src/pymadng/bin/mad_Linux src/pymadng/bin/mad_Darwin
     - name: Build package
       run: python -m build

--- a/.github/workflows/test-pymadng.yml
+++ b/.github/workflows/test-pymadng.yml
@@ -33,8 +33,8 @@ jobs:
     - name: Get MAD Binaries
       run: |
         mkdir ./src/pymadng/bin
-        curl https://madx.web.cern.ch/releases/madng/1.1/mad-linux-1.1.11 -o ./src/pymadng/bin/mad_Linux
-        curl https://madx.web.cern.ch/releases/madng/1.1/mad-macos-1.1.11 -o ./src/pymadng/bin/mad_Darwin
+        curl https://madx.web.cern.ch/releases/madng/1.1/mad-linux-1.1.12 -o ./src/pymadng/bin/mad_Linux
+        curl https://madx.web.cern.ch/releases/madng/1.1/mad-macos-1.1.12 -o ./src/pymadng/bin/mad_Darwin
         chmod +x ./src/pymadng/bin/mad_Linux ./src/pymadng/bin/mad_Darwin
     - name: Install dependencies
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+0.9.1 (2026/03/31) \
+Dependabot updates and new MAD-NG version
+
 0.9.0 (2026/02/25) \
 Remove support for Python 3.10, now only supporting Python 3.11 and above. \
 Replaced incorrect Warning call with logging.warning for proper warning handling. \

--- a/src/pymadng/__init__.py
+++ b/src/pymadng/__init__.py
@@ -1,7 +1,7 @@
 from .madp_object import MAD
 
 __title__ = "pymadng"
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 
 __summary__ = "Python interface to MAD-NG running as subprocess"
 __uri__ = "https://github.com/MethodicalAcceleratorDesign/MAD-NG.py"

--- a/tests/inputs/example.log
+++ b/tests/inputs/example.log
@@ -27,7 +27,7 @@ match = MAD.match
 ***pymad.recv: [py:__err(true):send(MAD['env']['version'], false):__err(false)] 62 bytes
 ***pymad.send: [str_] 4 bytes
 ***pymad.send: binary data 4 bytes
-***pymad.send: [1.1.11] 6 bytes
+***pymad.send: [1.1.12] 6 bytes
 ***pymad.recv: binary data 4 bytes
 ***pymad.recv: [
 function __mklast__ (a, b, ...)


### PR DESCRIPTION
This PR updates the MAD-NG version from 1.1.11 to 1.1.12 and bumps the package version to 0.9.1.

## Changes
- Updated `.github/workflows/test-pymadng.yml`
- Updated `.github/workflows/python-publish.yml`
- Updated `tests/inputs/example.log`
- Updated `src/pymadng/__init__.py` (package version)
- Updated `CHANGELOG.md`

## MAD-NG Release
New MAD-NG version: 1.1.12
Major.minor: 1.1

## Package Release
New package version: 0.9.1

After merging this PR, create a release with tag `v0.9.1` to publish to PyPI.