### PR TITLE
Bump MAD-NG to 1.1.14 and pymadng to 0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+0.9.5 (2026/07/11) \
+Update pymadng version
+
 0.9.4 (2026/07/10) \
 Update MAD-NG version
 

--- a/src/pymadng/__init__.py
+++ b/src/pymadng/__init__.py
@@ -1,7 +1,7 @@
 from .madp_object import MAD
 
 __title__ = "pymadng"
-__version__ = "0.9.4"
+__version__ = "0.9.5"
 
 __summary__ = "Python interface to MAD-NG running as subprocess"
 __uri__ = "https://github.com/MethodicalAcceleratorDesign/MAD-NG.py"


### PR DESCRIPTION
This PR updates the MAD-NG version from 1.1.14 to 1.1.14 and bumps the package version to 0.9.5.

## Changes
- Updated `.github/workflows/test-pymadng.yml`
- Updated `.github/workflows/python-publish.yml`
- Updated `tests/inputs/example.log`
- Updated `src/pymadng/__init__.py` (package version)
- Updated `CHANGELOG.md`

## MAD-NG Release
New MAD-NG version: 1.1.14
Major.minor: 1.1

## Package Release
New package version: 0.9.5

After merging this PR, create a release with tag `v0.9.5` to publish to PyPI.